### PR TITLE
add option to exclude list of fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ It will be an array with the following format:
 
 The kind property is here to help differentiate value cast to strings by javascript clients, such as enum values.
 
+### Exclude specific fields 
+Most of the time we don't need `__typename` to be sent to backend/rest api, we can exclude `__typename` using this:
+```javascript
+const graphqlFields = require('graphql-fields');
+const fieldsWithoutTypeName = graphqlFields(info, {}, { excludedFields: ['__typename'] });
+```
 ## Why
 An underlying REST api may only return fields based on query params.
 ```graphql

--- a/index.js
+++ b/index.js
@@ -41,6 +41,9 @@ function flattenAST(ast, info, obj) {
             flattened = flattenAST(getAST(a, info), info, flattened);
         } else {
             const name = a.name.value;
+            if (options.excludedFields.indexOf(name) !== -1) {
+              return flattened;
+            }
             if (flattened[name] && flattened[name] !== '__arguments') {
                 Object.assign(flattened[name], flattenAST(a, info, flattened[name]));
             } else {
@@ -61,6 +64,7 @@ function flattenAST(ast, info, obj) {
 module.exports = function graphqlFields(info, obj = {}, opts = { processArguments: false }) {
     const fields = info.fieldNodes || info.fieldASTs;
     options.processArguments = opts.processArguments;
+    options.excludedFields = opts.excludedFields || [];
     return fields.reduce((o, ast) => {
             return flattenAST(ast, info, o);
     }, obj) || {};

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -264,4 +264,60 @@ describe('graphqlFields', () => {
                 })
         });
     });
+    describe('excluded fields', function () {
+        let info = {};
+        const schemaString = /* GraphQL*/ `
+            type Person {
+                name: String!
+                age: Int!
+            }
+            type Query {
+                person: Person!
+            }
+        `;
+        const schema = graphql.buildSchema(schemaString);
+        const root = {
+            person(args, ctx, i) {
+                info = i;
+                return {
+                    name: 'john doe',
+                    age: 42,
+                };
+            },
+        };
+        const query = /* GraphQL */ `
+            {
+                person {
+                    name
+                    age
+                    __typename
+                }
+            }
+        `;
+        it('Should exclude fields', function (done) {
+            const expected = {
+                name: {},
+            };
+            graphql.graphql(schema, query, root, {})
+                .then(() => {
+                    const fields = graphqlFields(info, {}, { excludedFields: ['__typename', 'age'] });
+                    assert.deepStrictEqual(fields, expected);
+                    done();
+                });
+        });
+
+        it('Should not exculde fields if not specified in options', function (done) {
+            const expected = {
+                name: {},
+                age: {},
+                __typename: {},
+            };
+            graphql.graphql(schema, query, root, {})
+                .then(() => {
+                    const fields = graphqlFields(info);
+                    assert.deepStrictEqual(fields, expected);
+                    done();
+                })
+        });
+    });
 });


### PR DESCRIPTION
We have to exclude `__typename` manually every time we request fields from the backend service, it would be great if we have an option to do this automatically.