### PR TITLE
 respect @skip and @include directives when generating field map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.0 (2018-11-29)
+
+### Added
+
+- @skip and @include directive parsing
+
 ## 1.3.0 (2018-11-15)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # graphql-fields
-Turns GraphQLResolveInfo into a map of the requested fields. Flattens all fragments and duplicated fields into a neat object to easily see which fields were requested at any level.
+Turns GraphQLResolveInfo into a map of the requested fields. Flattens all fragments and duplicated fields into a neat object to easily see which fields were requested at any level. Takes into account any `@include` or `@skip` directives, excluding fields/fragments which are `@include(if: $false)` or `@skip(if: $true)`.
 
 ## Usage
 
@@ -16,7 +16,9 @@ const UserType = new graphql.GraphQLObjectType({
           fields: {
             firstName: {type: graphql.GraphQLString},
             lastName: {type: graphql.GraphQLString},
-            middleName: {type: graphql.GraphQLString}
+            middleName: {type: graphql.GraphQLString},
+            nickName: {type: graphql.GraphQLString},
+            maidenName: {type: graphql.GraphQLString}
           }
         }),
         email: {type: graphql.GraphQLString},
@@ -65,12 +67,14 @@ fragment A on User {
 
 Fragment B on Profile {
   firstName
+  nickName @skip(if: true)
 }
 
 Fragment C on User {
   email,
   profile {
     middleName
+    maidenName @include(if: false)
   }
 }
 ```

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function getArguments (ast) {
     });
 }
 
-function getDirectiveValue(directive, info, defaultVal) {
+function getDirectiveValue(directive, info) {
     const arg = directive.arguments[0]; // only arg on an include or skip directive is "if"
     if (arg.value.kind !== "Variable") {
         return !!arg.value.value;

--- a/index.js
+++ b/index.js
@@ -34,9 +34,42 @@ function getArguments (ast) {
     });
 }
 
+function getDirectiveValue(directive, info, defaultVal) {
+    const arg = directive.arguments[0]; // only arg on an include or skip directive is "if"
+    if (arg.value.kind !== "Variable") {
+        return !!arg.value.value;
+    }
+    return info.variableValues[arg.value.name.value];
+}
+
+function getDirectiveResults(ast, info) {
+    const directiveResult = {
+        shouldInclude: true,
+        shouldSkip: false,
+    };
+    return ast.directives.reduce((result, directive) => {
+        switch (directive.name.value) {
+            case "include":
+                return { ...result, shouldInclude: getDirectiveValue(directive, info) };
+            case "skip":
+                return { ...result, shouldSkip: getDirectiveValue(directive, info) };
+            default:
+                return result;
+        }
+    }, directiveResult);
+}
+
 function flattenAST(ast, info, obj) {
     obj = obj || {};
     return getSelections(ast).reduce((flattened, a) => {
+        if (a.directives && a.directives.length) {
+            const { shouldInclude, shouldSkip } = getDirectiveResults(a, info);
+            // field/fragment is not included if either the @skip condition is true or the @include condition is false
+            // https://facebook.github.io/graphql/draft/#sec--include
+            if (shouldSkip || !shouldInclude) {
+                return flattened;
+            }
+        }
         if (isFragment(a)) {
             flattened = flattenAST(getAST(a, info), info, flattened);
         } else {

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -176,244 +176,73 @@ describe('graphqlFields', () => {
     });
     describe('should respect include/skip directives when generating the field map', () => {
       let info = {};
-      const schema = new graphql.GraphQLSchema({
-          query: new graphql.GraphQLObjectType({
-              name: 'Query',
-              fields: {
-                  viewer: {
-                      type: new graphql.GraphQLObjectType({
-                          name: 'Viewer',
-                          fields: {
-                              users: {
-                                  args: {
-                                      userId: { type: graphql.GraphQLString },
-                                      first: { type: graphql.GraphQLInt },
-                                      includeInactive: { type: graphql.GraphQLBoolean }
-                                  },
-                                  type: new graphql.GraphQLObjectType({
-                                      name: 'UserConnection',
-                                      fields: {
-                                          pageInfo: {
-                                              type: new graphql.GraphQLObjectType({
-                                                  name: 'PageInfo',
-                                                  fields: {
-                                                      totalResults: { type: graphql.GraphQLInt }
-                                                  }
-                                              })
-                                          },
-                                          edges: {
-                                              type: new graphql.GraphQLList(
-                                                  new graphql.GraphQLObjectType({
-                                                      name: 'UserEdge',
-                                                      fields: {
-                                                          cursor: { type: graphql.GraphQLString },
-                                                          node: {
-                                                              type: new graphql.GraphQLObjectType({
-                                                                  name: 'User',
-                                                                  fields: {
-                                                                      addressBook: {
-                                                                          type: new graphql.GraphQLObjectType({
-                                                                              name: 'AddressBook',
-                                                                              fields: {
-                                                                                  apiType: { type: graphql.GraphQLString }
-                                                                              }
-                                                                          })
-                                                                      },
-                                                                      profile: {
-                                                                          type: new graphql.GraphQLObjectType({
-                                                                              name: 'Profile',
-                                                                              fields: {
-                                                                                  displayName: { type: graphql.GraphQLString },
-                                                                                  email: { type: graphql.GraphQLString }
-                                                                              }
-                                                                          })
-                                                                      },
-                                                                      proProfile: {
-                                                                          type: new graphql.GraphQLObjectType({
-                                                                              name: 'ProProfile',
-                                                                              fields: {
-                                                                                  apiType: { type: graphql.GraphQLString }
-                                                                              }
-                                                                          })
-                                                                      }
-                                                                  }
-                                                              })
-                                                          }
-                                                      }
-                                                  })
-                                              )
-                                          }
-                                      }
-                                  })
-                              }
-                          }
-                      }),
-                      resolve(root, args, context, i) {
-                          info = i;
-                          return {};
-                      }
-                  }
-              }
-          })
-      });
+      const schemaString = /* GraphQL*/ `
+            type Hobbie {
+                name: String!
+            }
+            type Person {
+                name: String!
+                age: Int!
+                hobbies: [Hobbie!]
+            }
+            type Query {
+                person: Person!
+            }
+        `;
+        const schema = graphql.buildSchema(schemaString);
+        const root = {
+            person(args, ctx, i) {
+                info = i;
+                return {
+                    name: 'john doe',
+                    age: 42,
+                };
+            },
+        };
       it('does not include fields with a false include directive', done => {
-        const query = `
-        query UsersRoute($shouldInclude: Boolean!) {
-          viewer {
-            users(userId:"123",first:25,includeInactive:true) {
-              ...A
-              ...D
-                pageInfo {
-                totalResults
-              }
-
-            }
-          }
-        }
-
-        fragment A on UserConnection {
-          edges {
-            node {
-              addressBook {
-                apiType
-              }
-            }
-          }
-          ...B
-        }
-        fragment B on UserConnection {
-          ...C
-          edges {
-            cursor
-          }
-        }
-
-        fragment C on UserConnection {
-          edges {
-            cursor
-            node {
-                profile {
-                    displayName
-                    email @include(if: false)
+        const query = /* GraphQL */ `
+            query Query($shouldInclude: Boolean!){
+                person {
+                    name @include(if: $shouldInclude)
+                    age @include(if: false) @skip(if: false)
+                    hobbies {
+                        name
+                    }
                 }
             }
-          }
-        }
-        fragment D on UserConnection {
-          edges {
-            node {
-              proProfile @include(if: $shouldInclude){
-                apiType
-              }
-            }
-          }
-          ...B
-        }
-      `;
-
-
-      graphql.graphql(schema, query, null, {}, { ["shouldInclude"]: false })
-          .then(() => {
-              const expected = {
-                  users: {
-                      pageInfo: {
-                          totalResults: {}
-                      },
-                      edges: {
-                          cursor: {},
-                          node: {
-                              addressBook: {
-                                  apiType: {}
-                              },
-                              profile: {
-                                  displayName: {},
-                              }
-                          }
-                      }
-                  }
-              };
-              assert.deepStrictEqual(graphqlFields(info), expected);
-              done();
-          }).catch(done);
+        `;
+        graphql.graphql(schema, query, root, {}, { ["shouldInclude"]: false })
+            .then(() => {
+                const expected = {
+                    hobbies: {
+                      name: {}
+                    }
+                };
+                assert.deepStrictEqual(graphqlFields(info), expected);
+                done();
+            }).catch(done);
       });
       it('does not include fields with a true skip directive', done => {
-        const query = `
-        query UsersRoute($shouldSkip: Boolean!) {
-          viewer {
-            users(userId:"123",first:25,includeInactive:true) @skip(if:false) {
-              ...A
-              ...D
-                pageInfo {
-                totalResults
-              }
-
-            }
-          }
-        }
-
-        fragment A on UserConnection {
-          edges {
-            node {
-              addressBook {
-                apiType @skip(if: $shouldSkip)
-              }
-            }
-          }
-          ...B
-        }
-        fragment B on UserConnection {
-          ...C
-          edges {
-            cursor
-          }
-        }
-
-        fragment C on UserConnection {
-          edges {
-            cursor
-            node {
-                profile {
-                    displayName
-                    email
+        const query = /* GraphQL */ `
+            query Query($shouldSkip: Boolean!){
+                person {
+                    name @skip(if: $shouldSkip)
+                    age
+                    hobbies {
+                        name @skip(if: true) @include(if: true)
+                    }
                 }
             }
-          }
-        }
-        fragment D on UserConnection {
-          edges {
-            node {
-              proProfile @skip(if: true){
-                apiType
-              }
-            }
-          }
-          ...B
-        }
-      `;
-
-
-      graphql.graphql(schema, query, null, {}, { ["shouldSkip"]: true })
-          .then(() => {
-              const expected = {
-                  users: {
-                      pageInfo: {
-                          totalResults: {}
-                      },
-                      edges: {
-                          cursor: {},
-                          node: {
-                              addressBook: {},
-                              profile: {
-                                  displayName: {},
-                                  email: {}
-                              }
-                          }
-                      }
-                  }
-              };
-              assert.deepStrictEqual(graphqlFields(info), expected);
-              done();
-          }).catch(done);
+        `;
+        graphql.graphql(schema, query, root, {}, { ["shouldSkip"]: true })
+            .then(() => {
+                const expected = {
+                    age: {},
+                    hobbies: {}
+                };
+                assert.deepStrictEqual(graphqlFields(info), expected);
+                done();
+            }).catch(done);
       });
     });
     describe('subfield argument parsing', function () {

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -7,7 +7,7 @@ const assert = require('assert');
 const util = require('util');
 
 describe('graphqlFields', () => {
-    it('should flatten fragments', function (done) {
+    describe('it should flatten fragments', function () {
         let info = {};
         const schema = new graphql.GraphQLSchema({
             query: new graphql.GraphQLObjectType({
@@ -89,60 +89,59 @@ describe('graphqlFields', () => {
                 }
             })
         });
-
-
-        const query = `
-        query UsersRoute {
-          viewer {
-            users(userId:"123",first:25,includeInactive:true) @skip(if:false) {
-              ...A
-              ...D
-                pageInfo {
-                totalResults
-              }
-
-            }
-          }
-        }
-
-        fragment A on UserConnection {
-          edges {
-            node {
-              addressBook {
-                apiType
-              }
-            }
-          }
-          ...B
-        }
-        fragment B on UserConnection {
-          ...C
-          edges {
-            cursor
-          }
-        }
-
-        fragment C on UserConnection {
-          edges {
-            cursor,
-            node {
-                profile {
-                    displayName,
-                    email
+        it('flattens the fragments', done => {
+          const query = `
+          query UsersRoute {
+            viewer {
+              users(userId:"123",first:25,includeInactive:true) @skip(if:false) {
+                ...A
+                ...D
+                  pageInfo {
+                  totalResults
                 }
-            }
-          }
-        }
-        fragment D on UserConnection {
-          edges {
-            node {
-              proProfile {
-                apiType
+
               }
             }
           }
-          ...B
-        }
+
+          fragment A on UserConnection {
+            edges {
+              node {
+                addressBook {
+                  apiType
+                }
+              }
+            }
+            ...B
+          }
+          fragment B on UserConnection {
+            ...C
+            edges {
+              cursor
+            }
+          }
+
+          fragment C on UserConnection {
+            edges {
+              cursor,
+              node {
+                  profile {
+                      displayName,
+                      email
+                  }
+              }
+            }
+          }
+          fragment D on UserConnection {
+            edges {
+              node {
+                proProfile {
+                  apiType
+                }
+              }
+            }
+            ...B
+          }
         `;
 
 
@@ -173,6 +172,166 @@ describe('graphqlFields', () => {
                 assert.deepStrictEqual(graphqlFields(info), expected);
                 done();
             }).catch(done);
+        });
+        it('does not include fields with a false include directive', done => {
+          const query = `
+          query UsersRoute($shouldInclude: Boolean!) {
+            viewer {
+              users(userId:"123",first:25,includeInactive:true) {
+                ...A
+                ...D
+                  pageInfo {
+                  totalResults
+                }
+
+              }
+            }
+          }
+
+          fragment A on UserConnection {
+            edges {
+              node {
+                addressBook {
+                  apiType
+                }
+              }
+            }
+            ...B
+          }
+          fragment B on UserConnection {
+            ...C
+            edges {
+              cursor
+            }
+          }
+
+          fragment C on UserConnection {
+            edges {
+              cursor
+              node {
+                  profile {
+                      displayName
+                      email @include(if: false)
+                  }
+              }
+            }
+          }
+          fragment D on UserConnection {
+            edges {
+              node {
+                proProfile @include(if: $shouldInclude){
+                  apiType
+                }
+              }
+            }
+            ...B
+          }
+        `;
+
+
+        graphql.graphql(schema, query, null, {}, { ["shouldInclude"]: false })
+            .then(() => {
+                const expected = {
+                    users: {
+                        pageInfo: {
+                            totalResults: {}
+                        },
+                        edges: {
+                            cursor: {},
+                            node: {
+                                addressBook: {
+                                    apiType: {}
+                                },
+                                profile: {
+                                    displayName: {},
+                                }
+                            }
+                        }
+                    }
+                };
+                assert.deepStrictEqual(graphqlFields(info), expected);
+                done();
+            }).catch(done);
+        });
+        it('does not include fields with a true skip directive', done => {
+          const query = `
+          query UsersRoute($shouldSkip: Boolean!) {
+            viewer {
+              users(userId:"123",first:25,includeInactive:true) @skip(if:false) {
+                ...A
+                ...D
+                  pageInfo {
+                  totalResults
+                }
+
+              }
+            }
+          }
+
+          fragment A on UserConnection {
+            edges {
+              node {
+                addressBook {
+                  apiType @skip(if: $shouldSkip)
+                }
+              }
+            }
+            ...B
+          }
+          fragment B on UserConnection {
+            ...C
+            edges {
+              cursor
+            }
+          }
+
+          fragment C on UserConnection {
+            edges {
+              cursor
+              node {
+                  profile {
+                      displayName
+                      email
+                  }
+              }
+            }
+          }
+          fragment D on UserConnection {
+            edges {
+              node {
+                proProfile @skip(if: true){
+                  apiType
+                }
+              }
+            }
+            ...B
+          }
+        `;
+
+
+        graphql.graphql(schema, query, null, {}, { ["shouldSkip"]: true })
+            .then(() => {
+                const expected = {
+                    users: {
+                        pageInfo: {
+                            totalResults: {}
+                        },
+                        edges: {
+                            cursor: {},
+                            node: {
+                                addressBook: {},
+                                profile: {
+                                    displayName: {},
+                                    email: {}
+                                }
+                            }
+                        }
+                    }
+                };
+                assert.deepStrictEqual(graphqlFields(info), expected);
+                done();
+            }).catch(done);
+        });
     });
 
     describe('subfield argument parsing', function () {


### PR DESCRIPTION
when fields/fragments have `@skip(if: true)` or `@include(if: false)` directives on them, we should remove them from the object returned by `graphql-fields`, so as to mirror more accurately the data returned by the graphql query.

ex:
```
query MyQuery ($shouldGetName: Boolean!, $shouldSkipAddress: Boolean!) {
    viewer: {
        name @include(if: $shouldGetName)
        address @skip(if: $shouldSkipAddress)
        phoneNumber
    }
}

// variables
{
    shouldGetName: false,
    shouldSkipAddress: true
}
```
returns:
```
{
   viewer: {
      phoneNumber: {}
   }
}
```