### PR TITLE
Add possibility to process ListValue subfield arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,10 +25,13 @@ function getAST(ast, info) {
 
 function getArguments (ast) {
     return ast.arguments.map(argument => {
+        const argumentValue = argument.value.kind !== 'ListValue' ? argument.value.value :
+            argument.value.values.map(value => value.value);
+
         return {
             [argument.name.value]: {
                 kind: argument.value.kind,
-                value: argument.value.value,
+                value: argumentValue
             },
         };
     });

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -254,7 +254,7 @@ describe('graphqlFields', () => {
             type Person {
                 name (case: String): String!
                 age: Int!
-                hobbies(first: Int, sort: Boolean): [Hobbie!]
+                hobbies(first: Int, sort: Boolean, categories: [String]): [Hobbie!]
             }
             type Query {
                 person: Person!
@@ -275,7 +275,7 @@ describe('graphqlFields', () => {
                 person {
                     name (case: "upper")
                     age
-                    hobbies (first: 2, sort: true) {
+                    hobbies (first: 2, sort: true, categories: ["sports", "music"]) {
                         name
                     }
                 }
@@ -305,6 +305,12 @@ describe('graphqlFields', () => {
                             sort: {
                                 kind: 'BooleanValue',
                                 value: true,
+                            }
+                        },
+                        {
+                            categories: {
+                                kind: 'ListValue',
+                                value: ['sports', 'music'],
                             }
                         }
                     ],


### PR DESCRIPTION
ListValue argument type is not processed in current implementation - the result is just `undefined`. `argument.value.value` is accessed in `getArguments` during mapping (which is `undefined`) so I added a simple condition that checks if current argument has a ListValue type - if yes `argument.value.values` prop is used and mapped.