### PR TITLE
Code Cleanup

### DIFF
--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -1,10 +1,8 @@
 'use strict';
 
 const graphql = require('graphql');
-const parse = require('graphql/language').parse;
 const graphqlFields = require('../index');
 const assert = require('assert');
-const util = require('util');
 
 describe('graphqlFields', () => {
     it('should flatten fragments', function (done) {
@@ -145,7 +143,6 @@ describe('graphqlFields', () => {
         }
         `;
 
-
         graphql.graphql(schema, query, null, {})
             .then(() => {
                 const expected = {
@@ -177,13 +174,13 @@ describe('graphqlFields', () => {
     describe('should respect include/skip directives when generating the field map', () => {
       let info = {};
       const schemaString = /* GraphQL*/ `
-            type Hobbie {
+            type Hobby {
                 name: String!
             }
             type Person {
                 name: String!
                 age: Int!
-                hobbies: [Hobbie!]
+                hobbies: [Hobby!]
             }
             type Query {
                 person: Person!
@@ -248,13 +245,13 @@ describe('graphqlFields', () => {
     describe('subfield argument parsing', function () {
         let info = {};
         const schemaString = /* GraphQL*/ `
-            type Hobbie {
+            type Hobby {
                 name: String!
             }
             type Person {
                 name (case: String): String!
                 age: Int!
-                hobbies(first: Int, sort: Boolean, categories: [String]): [Hobbie!]
+                hobbies(first: Int, sort: Boolean, categories: [String]): [Hobby!]
             }
             type Query {
                 person: Person!
@@ -382,7 +379,7 @@ describe('graphqlFields', () => {
                 });
         });
 
-        it('Should not exculde fields if not specified in options', function (done) {
+        it('Should not exclude fields if not specified in options', function (done) {
             const expected = {
                 name: {},
                 age: {},

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -242,7 +242,7 @@ describe('graphqlFields', () => {
             }).catch(done);
       });
     });
-    describe('subfield argument parsing', function() {
+    describe('subfield argument parsing', function () {
         let info = {};
         const schemaString = /* GraphQL*/ `
             type Hobby {
@@ -268,7 +268,7 @@ describe('graphqlFields', () => {
             }
         };
 
-        it('should extract sub-field arguments of Variable type if options is provided', function(done) {
+        it('should extract sub-field arguments of Variable type if options is provided', function (done) {
             const variableValues = {
                 first: 50
             };
@@ -310,7 +310,7 @@ describe('graphqlFields', () => {
                 });
         });
 
-        it('should extract sub-field arguments of ListValue type if options is provided', function(done) {
+        it('should extract sub-field arguments of ListValue type if options is provided', function (done) {
             const variableValues = {
                 category: 'music'
             };
@@ -352,7 +352,7 @@ describe('graphqlFields', () => {
                 });
         });
 
-        it('should extract sub-field arguments of default type if options is provided', function(done) {
+        it('should extract sub-field arguments of default type if options is provided', function (done) {
             const query = /* GraphQL */ `
                 {
                     person {
@@ -416,7 +416,7 @@ describe('graphqlFields', () => {
             });
         });
 
-        it('should not parse arguments if not specified in options', function(done) {
+        it('should not parse arguments if not specified in options', function (done) {
             const query = /* GraphQL */ `
                 {
                     person {


### PR DESCRIPTION
Removes some unused imports (i.e., `require`s).
Fixed misspellings.
Fixed a typo.
Code formatting.

I had planned this to be apart of a different PR but another PR was approved after I had forked. I think it will be a little cleaner to push these changes separately.
