### PR TITLE
Allow ObjectValue (aka Input) Arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function getAST(ast, info) {
     return ast;
 }
 
-function getArguments (ast, info) {
+function getArguments(ast, info) {
     return ast.arguments.map(argument => {
         const argumentValue = getArgumentValue(argument.value, info);
 
@@ -38,10 +38,22 @@ function getArguments (ast, info) {
 
 function getArgumentValue(arg, info) {
     switch (arg.kind) {
+        case 'FloatValue':
+            return parseFloat(arg.value);
+        case 'IntValue':
+            return parseInt(arg.value, 10);
         case 'Variable':
             return info.variableValues[arg.name.value];
         case 'ListValue':
             return arg.values.map(argument => getArgumentValue(argument, info));
+        case 'ObjectValue':
+            return arg.fields.reduce(
+                (argValue, objectField) => {
+                    argValue[objectField.name.value] = getArgumentValue(objectField.value, info);
+                    return argValue;
+                },
+                {},
+            );
         default:
             return arg.value;
     }

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -1,10 +1,8 @@
 'use strict';
 
 const graphql = require('graphql');
-const parse = require('graphql/language').parse;
 const graphqlFields = require('../index');
 const assert = require('assert');
-const util = require('util');
 
 describe('graphqlFields', () => {
     it('should flatten fragments', function (done) {
@@ -145,7 +143,6 @@ describe('graphqlFields', () => {
         }
         `;
 
-
         graphql.graphql(schema, query, null, {})
             .then(() => {
                 const expected = {
@@ -177,13 +174,13 @@ describe('graphqlFields', () => {
     describe('should respect include/skip directives when generating the field map', () => {
       let info = {};
       const schemaString = /* GraphQL*/ `
-            type Hobbie {
+            type Hobby {
                 name: String!
             }
             type Person {
                 name: String!
                 age: Int!
-                hobbies: [Hobbie!]
+                hobbies: [Hobby!]
             }
             type Query {
                 person: Person!
@@ -248,13 +245,13 @@ describe('graphqlFields', () => {
     describe('subfield argument parsing', function () {
         let info = {};
         const schemaString = /* GraphQL*/ `
-            type Hobbie {
+            type Hobby {
                 name: String!
             }
             type Person {
                 name (case: String): String!
                 age: Int!
-                hobbies(first: Int, sort: Boolean, categories: [String]): [Hobbie!]
+                hobbies(first: Int, sort: Boolean, categories: [String]): [Hobby!]
             }
             type Query {
                 person: Person!
@@ -382,7 +379,7 @@ describe('graphqlFields', () => {
                 });
         });
 
-        it('Should not exculde fields if not specified in options', function (done) {
+        it('Should not exclude fields if not specified in options', function (done) {
             const expected = {
                 name: {},
                 age: {},

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -174,13 +174,13 @@ describe('graphqlFields', () => {
     describe('should respect include/skip directives when generating the field map', () => {
       let info = {};
       const schemaString = /* GraphQL*/ `
-            type Hobby {
+            type Pet {
                 name: String!
             }
             type Person {
                 name: String!
                 age: Int!
-                hobbies: [Hobby!]
+                pets: [Pet!]
             }
             type Query {
                 person: Person!
@@ -202,7 +202,7 @@ describe('graphqlFields', () => {
                 person {
                     name @include(if: $shouldInclude)
                     age @include(if: false) @skip(if: false)
-                    hobbies {
+                    pets {
                         name
                     }
                 }
@@ -211,7 +211,7 @@ describe('graphqlFields', () => {
         graphql.graphql(schema, query, root, {}, { ["shouldInclude"]: false })
             .then(() => {
                 const expected = {
-                    hobbies: {
+                    pets: {
                       name: {}
                     }
                 };
@@ -225,7 +225,7 @@ describe('graphqlFields', () => {
                 person {
                     name @skip(if: $shouldSkip)
                     age
-                    hobbies {
+                    pets {
                         name @skip(if: true) @include(if: true)
                     }
                 }
@@ -235,7 +235,7 @@ describe('graphqlFields', () => {
             .then(() => {
                 const expected = {
                     age: {},
-                    hobbies: {}
+                    pets: {}
                 };
                 assert.deepStrictEqual(graphqlFields(info), expected);
                 done();
@@ -245,13 +245,13 @@ describe('graphqlFields', () => {
     describe('subfield argument parsing', function () {
         let info = {};
         const schemaString = /* GraphQL*/ `
-            type Hobby {
+            type Pet {
                 name: String!
             }
             type Person {
                 name (case: String): String!
                 age: Int!
-                hobbies(first: Int, sort: Boolean, categories: [String]): [Hobby!]
+                pets(first: Int, sort: Boolean, categories: [String]): [Pet!]
             }
             type Query {
                 person: Person!
@@ -276,7 +276,7 @@ describe('graphqlFields', () => {
             const query = /* GraphQL */ `
                 query Query($first: Int) {
                     person {
-                        hobbies(first: $first) {
+                        pets(first: $first) {
                             name
                         }
                     }
@@ -284,7 +284,7 @@ describe('graphqlFields', () => {
             `;
 
             const expected = {
-                hobbies: {
+                pets: {
                     __arguments: [
                         {
                             first: {
@@ -318,7 +318,7 @@ describe('graphqlFields', () => {
             const query = /* GraphQL */ `
                 query Query($category: String) {
                     person {
-                        hobbies(categories: ["sports", $category]) {
+                        pets(categories: ["sports", $category]) {
                             name
                         }
                     }
@@ -326,7 +326,7 @@ describe('graphqlFields', () => {
             `;
 
             const expected = {
-                hobbies: {
+                pets: {
                     __arguments: [
                         {
                             categories: {
@@ -358,7 +358,7 @@ describe('graphqlFields', () => {
                     person {
                         name(case: "upper")
                         age
-                        hobbies(
+                        pets(
                             first: 2
                             sort: true
                             categories: ["sports", "music"]
@@ -381,7 +381,7 @@ describe('graphqlFields', () => {
                     ]
                 },
                 age: {},
-                hobbies: {
+                pets: {
                     name: {},
                     __arguments: [
                         {
@@ -422,7 +422,7 @@ describe('graphqlFields', () => {
                     person {
                         name(case: "upper")
                         age
-                        hobbies(
+                        pets(
                             first: 2
                             sort: true
                             categories: ["sports", "music"]
@@ -436,7 +436,7 @@ describe('graphqlFields', () => {
             const expected = {
                 name: {},
                 age: {},
-                hobbies: {
+                pets: {
                     name: {}
                 }
             };

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -242,7 +242,7 @@ describe('graphqlFields', () => {
             }).catch(done);
       });
     });
-    describe('subfield argument parsing', function() {
+    describe('subfield argument parsing', function () {
         let info = {};
         const schemaString = /* GraphQL*/ `
             type Hobby {
@@ -268,7 +268,7 @@ describe('graphqlFields', () => {
             }
         };
 
-        it('should extract sub-field arguments of Variable type if options is provided', function(done) {
+        it('should extract sub-field arguments of Variable type if options is provided', function (done) {
             const variableValues = {
                 first: 50
             };
@@ -310,7 +310,7 @@ describe('graphqlFields', () => {
                 });
         });
 
-        it('should extract sub-field arguments of ListValue type if options is provided', function(done) {
+        it('should extract sub-field arguments of ListValue type if options is provided', function (done) {
             const variableValues = {
                 category: 'music'
             };
@@ -352,7 +352,7 @@ describe('graphqlFields', () => {
                 });
         });
 
-        it('should extract sub-field arguments of default type if options is provided', function(done) {
+        it('should extract sub-field arguments of default type if options is provided', function (done) {
             const query = /* GraphQL */ `
                 {
                     person {
@@ -416,7 +416,7 @@ describe('graphqlFields', () => {
             });
         });
 
-        it('should not parse arguments if not specified in options', function(done) {
+        it('should not parse arguments if not specified in options', function (done) {
             const query = /* GraphQL */ `
                 {
                     person {


### PR DESCRIPTION
This PR allows ObjectValue (aka Input) arguments. It doesn't use nested `{ kind: ..., value: ... }` meta objects to describe the object fields. I know we discussed using the nested structure for consistency but it turned out to be harder to implement and the nested structure is just obnoxiously verbose. Also, this aligns well with the shallow structure that a `ListValue` currently uses. This change is still backwards compatible except possible for the part where floats and ints are now parsed to actual numbers. (Please let me know if you want this parsing removed.) For whatever reason, GraphQL doesn't already have them parsed in the resolve info structure.

BTW, in the tests, I swapped out Hobby for Pet. I found it easier to come up with properties of different data types for pets than for hobbies.