### PR TITLE
Extract arguments with the same field

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,12 @@ function flattenAST(ast, info, obj) {
             if (options.processArguments) {
                 // check if the current field has arguments
                 if (a.arguments && a.arguments.length) {
-                    Object.assign(flattened[name], { __arguments: getArguments(a, info) });
+                    const __arguments = [
+                        ...(flattened[name].__arguments ? flattened[name].__arguments : []),
+                        ...getArguments(a, info),
+                    ]
+
+                    Object.assign(flattened[name], { __arguments });
                 }
             }
         }

--- a/test/index_spec.js
+++ b/test/index_spec.js
@@ -425,7 +425,8 @@ describe('graphqlFields', () => {
             const query = /* GraphQL */ `
                 {
                     person {
-                        name(case: "upper")
+                        upperName: name(case: "upper")
+                        lowerName: name(case: "lower")
                         age
                         pets(
                             id: "A",
@@ -474,6 +475,12 @@ describe('graphqlFields', () => {
                             case: {
                                 kind: 'StringValue',
                                 value: 'upper'
+                            }
+                        },
+                        {
+                            case: {
+                                kind: 'StringValue',
+                                value: 'lower'
                             }
                         }
                     ]


### PR DESCRIPTION
In some case we use the same field with a different arguments, and with the lib we can't because we keep the last value.

```js
queryName(id: "") {
    id
    variables52: variables(year: 52) {
      name
    }
    variables40: variables(year: 40) {
      name
    }
}
```