### PR TITLE
allow for more succinct argument parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,16 +23,29 @@ function getAST(ast, info) {
     return ast;
 }
 
-function getArguments(ast, info) {
-    return ast.arguments.map(argument => {
-        const argumentValue = getArgumentValue(argument.value, info);
+function getArguments(ast, info, compact = false) {
+    if (compact) {
+        return ast.arguments.reduce((total, argument) => {
+            const argumentValue = getArgumentValue(argument.value, info);
 
-        return {
-            [argument.name.value]: {
+            total[argument.name.value] = {
                 kind: argument.value.kind,
                 value: argumentValue
-            },
-        };
+            };
+
+            return total;
+        }, {});
+    }
+
+    return ast.arguments.map(argument => {
+      const argumentValue = getArgumentValue(argument.value, info);
+
+      return {
+          [argument.name.value]: {
+              kind: argument.value.kind,
+              value: argumentValue
+          },
+      };
     });
 }
 
@@ -110,7 +123,7 @@ function flattenAST(ast, info, obj) {
             if (options.processArguments) {
                 // check if the current field has arguments
                 if (a.arguments && a.arguments.length) {
-                    Object.assign(flattened[name], { __arguments: getArguments(a, info) });
+                    Object.assign(flattened[name], { __arguments: getArguments(a, info, options.processArguments === 'compact') });
                 }
             }
         }


### PR DESCRIPTION
When the option `processArguments: "compact"` is specified, the `__arguments` list will be assembled as an object instead of an array. e.g.

```js
__arguments: { 
  argumentName: { kind: 'Variable', value: false },
  weight: {
      kind: 'FloatValue',
      value: 123.4
    },
}
```
vs
```js
__arguments: [
    {
        "argumentName": {
            "kind": "Variable",
            "value": false
        }
    },
    {
        "weight": {
            "kind": "FloatValue",
            "value": 123.4
        }
    }
]
```

this will also require an update to the type definitions located at:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/graphql-fields/index.d.ts